### PR TITLE
Fix pattern that sometimes ignores certain actions because of comment blocks within the code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,16 @@
 
+2.0.3
+---
+* Bugfix: sometimes certain actions would be ignored because of comment blocks within the code
+
+2.0.2
+---
+* Fixed issue with not escaping namespaces
+
+2.0.1
+---
+* Fixed slim dependency in composer.json
+
 2.0.0
 ---
 * Added support for latest version of Slim

--- a/Slim/Routing/Manager.php
+++ b/Slim/Routing/Manager.php
@@ -132,12 +132,12 @@ class Manager
     /**
      * This method writes the cache content into cache file
      *
-     * @param array $classes
-     * @param       $content
+     * @param array|null $classes
+     * @param string     $content
      *
      * @return string
      */
-    protected function writeCache(array $classes, $content)
+    protected function writeCache($classes, $content)
     {
         $modTimes = array();
         foreach ($classes as $classFile) {


### PR DESCRIPTION
Given this code:
```
    /**
     * DogController constructor.
     */
    public function __construct()
    {
        parent::__construct();

        /** @var DogRepository $dogRepository */
        $this->dogRepository = $entityManager->getRepository(Dog::class);
    }

    /**
     * Gets a single Dog
     *
     * @param string $id Dog ID
     *
     * @Route('/v2/dogs/:id')
     * @Method('GET')
     * @Name('dogs.index')
     *
     * @return array
     */
    public function indexAction($id)
    {
        return [];
    }
```

The regex would make two matches:
```
/**
     * DogController constructor.
     */
    public function __construct()
    {
```
```
/** @var DogRepository $dogRepository */
        $this->dogRepository = $entityManager->getRepository(Dog::class);
    }

    /**
     * Gets a single Dog
     *
     * @param string $id Dog ID
     *
     * @Route('/v2/dogs/:id')
     * @Method('GET')
     * @Name('dogs.index')
     *
     * @return array
     */
    public function indexAction($id)
    {
```

The expected result would be:
```
/**
     * DogController constructor.
     */
    public function __construct()
    {
```
```
/**
     * Gets a single Dog
     *
     * @param string $id Dog ID
     *
     * @Route('/v2/dogs/:id')
     * @Method('GET')
     * @Name('dogs.index')
     *
     * @return array
     */
    public function indexAction($id)
    {
```